### PR TITLE
Add port overrides to compose containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         links:
             - 'db:postgres'
         ports:
-            - '8000:80'
+            - '${HTTP_PORT:-8000}:80'
         volumes:
             - '.:/app:rw'
             - './data:/data:rw'
@@ -23,7 +23,7 @@ services:
             context: '.'
             dockerfile: frontend.Dockerfile
         ports:
-            - '8090:8090'
+            - '${FE_PORT:-8090}:8090'
         volumes:
             - '.:/app:rw'
             - node_modules:/app/frontend/node_modules
@@ -32,7 +32,7 @@ services:
     db:
         image: postgres:9.6-alpine
         ports:
-            - '5432:5432'
+            - '${DB_PORT:-5432}:5432'
         environment:
             POSTGRES_DB: 'db'
             POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
This allows environment variables to override the ports for the web, frontend and database containers. But will keep their defaults if no variables are defined.

For example, I've got 2 local postgres servers, running on ports 5432 and 5433. So to run this locally I need to be able to run the database on 5431, by doing `DB_PORT=5431 docker compose up`

Perhaps I've got another django project running, that's got port 80 bound. So I can instead run the web container here on port 81 using `HTTP_PORT=81 docker compose up`